### PR TITLE
Added UDP packet length extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The detailed description of dataset variables, Wireshark dissectors and other da
 | ws.protocol       | _ws.col.Protocol       | Protocol                                                   | x          | x         | category   |
 | ws.length         | _ws.col.Length         | Length (bytes)                                             | x          | x         | int16      |
 | ws.info           | _ws.col.Info           | Information                                                | x          | x         | object     |
+| udp.length        | udp.length             | UDP packet size (0 in case of N/A)                         | x          | x         | int16      |
 | srt.iscontrol     | srt.iscontrol          | Content type (CONTROL if 1, DATA if 0)                     | x          | x         | int8       |
 | srt.type          | srt.type               | Message type (e.g. UMSG_ACK, UMSG_ACKACK)                  | -          | x         | category   |
 | srt.seqno         | srt.seqno              | Sequence number                                            | x          | -         | int64      |

--- a/README.md
+++ b/README.md
@@ -87,31 +87,31 @@ This data is further cleaned and transformed using [pandas](https://pandas.pydat
 4. For DATA packets, the inter-arrival time is calculated as the difference between current and previous packet timestamps and stored as a separate variable `ws.iat.us`. Please note that the time delta for the first SRT data packet by default is equal to 0, that's why this packet might probably should be excluded from the analysis.
 5. The type conversion is performed to structure the data in appropriate formats.
 
-The detailed description of dataset variables, Wireshark dissectors and other data is provided in table below. See columns `DATA` and `CONTROL` to check whether the variable is present (`x`) or absent (`-`) in a corresponding dataset.
+The detailed description of dataset variables, Wireshark dissectors and other data is provided in table below. See columns `DATA` and `CONTROL` to check whether the variable is present (`✓`) or absent (`-`) in a corresponding dataset.
 
 | Dataset Variable  | Wireshark Dissector    | Description                                                | DATA       | CONTROL   | Data Type  |
 |:------------------|:-----------------------|:-----------------------------------------------------------|:-----------|:----------|:-----------|
-| ws.no             | _ws.col.No.            | Number as registered by Wireshark                          | x          | x         | int64      |
-| ws.time           | _ws.col.Time           | Timestamp as registered by Wireshark (seconds)             | x          | x         | float64    |
-| ws.source         | _ws.col.Source         | Source IP address                                          | x          | x         | category   |
-| ws.destination    | _ws.col.Destination    | Destination IP address                                     | x          | x         | category   |
-| ws.protocol       | _ws.col.Protocol       | Protocol                                                   | x          | x         | category   |
-| ws.length         | _ws.col.Length         | Length (bytes)                                             | x          | x         | int16      |
-| ws.info           | _ws.col.Info           | Information                                                | x          | x         | object     |
-| udp.length        | udp.length             | UDP packet size (0 in case of N/A)                         | x          | x         | int16      |
-| srt.iscontrol     | srt.iscontrol          | Content type (CONTROL if 1, DATA if 0)                     | x          | x         | int8       |
-| srt.type          | srt.type               | Message type (e.g. UMSG_ACK, UMSG_ACKACK)                  | -          | x         | category   |
-| srt.seqno         | srt.seqno              | Sequence number                                            | x          | -         | int64      |
-| srt.msg.rexmit    | srt.msg.rexmit         | Sent as original if 0, retransmitted if 1                  | x          | -         | int8       |
-| srt.timestamp     | srt.timestamp          | Timestamp since the socket was opened (microseconds)       | x          | x         | int64      |
-| srt.id            | srt.id                 | Destination socket id                                      | x          | x         | category   |
-| srt.ack_seqno     | srt.ack_seqno          | First unacknowledged sequence number                       | -          | x         | int64      |
-| srt.rate          | srt.rate               | Receiving speed estimation (packets/s)                     | -          | x         | int64      |
-| srt.bw            | srt.bw                 | Bandwidth estimation (packets/s)                           | -          | x         | int64      |
-| srt.rcvrate       | srt.rcvrate            | Receiving speed estimation (bytes/s)                       | -          | x         | int64      |
-| data.len          | data.len               | Payload size (bytes)                                       | x          | -         | int16      |
-| ws.time.us        | -                      | Timestamp as registered by Wireshark (microseconds)        | x          | -         | int64      |
-| ws.iat.us         | -                      | Packet inter-arrival time (microseconds)                   | x          | -         | int64      |
+| ws.no             | _ws.col.No.            | Number as registered by Wireshark                          | ✓          | ✓         | int64      |
+| ws.time           | _ws.col.Time           | Timestamp as registered by Wireshark (seconds)             | ✓          | ✓         | float64    |
+| ws.source         | _ws.col.Source         | Source IP address                                          | ✓          | ✓         | category   |
+| ws.destination    | _ws.col.Destination    | Destination IP address                                     | ✓          | ✓         | category   |
+| ws.protocol       | _ws.col.Protocol       | Protocol                                                   | ✓          | ✓         | category   |
+| ws.length         | _ws.col.Length         | Length (bytes)                                             | ✓          | ✓         | int16      |
+| ws.info           | _ws.col.Info           | Information                                                | ✓          | ✓         | object     |
+| udp.length        | udp.length             | UDP packet size (bytes)                                    | ✓          | ✓         | int16      |
+| srt.iscontrol     | srt.iscontrol          | Content type (CONTROL if 1, DATA if 0)                     | ✓          | ✓         | int8       |
+| srt.type          | srt.type               | Message type (e.g. UMSG_ACK, UMSG_ACKACK)                  | -          | ✓         | category   |
+| srt.seqno         | srt.seqno              | Sequence number                                            | ✓          | -         | int64      |
+| srt.msg.rexmit    | srt.msg.rexmit         | Sent as original if 0, retransmitted if 1                  | ✓          | -         | int8       |
+| srt.timestamp     | srt.timestamp          | Timestamp since the socket was opened (microseconds)       | ✓          | ✓         | int64      |
+| srt.id            | srt.id                 | Destination socket id                                      | ✓          | ✓         | category   |
+| srt.ack_seqno     | srt.ack_seqno          | First unacknowledged sequence number                       | -          | ✓         | int64      |
+| srt.rate          | srt.rate               | Receiving speed estimation (packets/s)                     | -          | ✓         | int64      |
+| srt.bw            | srt.bw                 | Bandwidth estimation (packets/s)                           | -          | ✓         | int64      |
+| srt.rcvrate       | srt.rcvrate            | Receiving speed estimation (bytes/s)                       | -          | ✓         | int64      |
+| data.len          | data.len               | Payload size or 0 in case of control packets (bytes)       | ✓          | -         | int16      |
+| ws.time.us        | -                      | Timestamp as registered by Wireshark (microseconds)        | ✓          | -         | int64      |
+| ws.iat.us         | -                      | Packet inter-arrival time (microseconds)                   | ✓          | -         | int64      |
 
 ## Probing DATA Packets
 

--- a/tcpdump_processing/convert.py
+++ b/tcpdump_processing/convert.py
@@ -76,6 +76,7 @@ def convert_to_csv(
 		'-e', '_ws.col.Protocol',
 		'-e', '_ws.col.Length',
 		'-e', '_ws.col.Info',
+		'-e', 'udp.length',
 		'-e', 'srt.iscontrol',
 		'-e', 'srt.type',
 		'-e', 'srt.seqno',

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -56,6 +56,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'_ws.col.Protocol',
 		'_ws.col.Length',
 		'_ws.col.Info',
+		'udp.length',
 		'srt.iscontrol',
 		'srt.type',
 		'srt.seqno',
@@ -77,6 +78,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'category',		# _ws.col.Protocol (ws.protocol)
 		'int16',		# _ws.col.Length (ws.length)
 		'object',		# _ws.col.Info (ws.info)
+		'float64',		# udp.length
 		'float16',		# srt.iscontrol
 		'category',		# srt.type
 		'float64',		# srt.seqno
@@ -101,6 +103,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'ws.protocol',
 		'ws.length',
 		'ws.info',
+		'udp.length',
 		'srt.iscontrol',
 		'srt.type',
 		'srt.seqno',
@@ -117,6 +120,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
+	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int64')
 
 	return srt_packets
 

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -78,7 +78,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'category',		# _ws.col.Protocol (ws.protocol)
 		'int16',		# _ws.col.Length (ws.length)
 		'object',		# _ws.col.Info (ws.info)
-		'float64',		# udp.length
+		'float16',		# udp.length
 		'float16',		# srt.iscontrol
 		'category',		# srt.type
 		'float64',		# srt.seqno
@@ -120,8 +120,8 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
-	srt_packets['data.len'] = srt_packets['data.len'].fillna(0).astype('int64')
-	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int64')
+	srt_packets['data.len'] = srt_packets['data.len'].fillna(0).astype('int16')
+	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int16')
 
 	return srt_packets
 

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -120,6 +120,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
+	srt_packets['data.len'] = srt_packets['data.len'].fillna(0).astype('int64')
 	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int64')
 
 	return srt_packets

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -120,8 +120,8 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
-	srt_packets['data.len'] = srt_packets['data.len'].fillna(0).astype('int16')
 	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int16')
+	srt_packets['data.len'] = srt_packets['data.len'].fillna(0).astype('int16')
 
 	return srt_packets
 


### PR DESCRIPTION
- Length of an UDP packet is usefull to check overall SRT+UDP overhead.
- Set type of `data.len` field as `int64`. NA values are converted to 0