### PR TITLE
Fix in CEST timezone bug

### DIFF
--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -142,7 +142,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	# It's either a dataframe with SRT only packets or an empty dataframe
 	# if there is no SRT packets in packets dataframe
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
-	srt_packets['frame.time'] = pd.to_datetime(srt_packets['frame.time'], format='%b %d, %Y %H:%M:%S.%f %Z')
+	srt_packets['frame.time'] = pd.to_datetime(srt_packets['frame.time'])
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
 	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int16')


### PR DESCRIPTION
I ran on the same problem mentioned in [Issue #22 ](https://github.com/mbakholdina/lib-tcpdump-processing/issues/22) this might work to fix it

Example of the outputs and difference with previous method:

`date_string_cet = 'Apr 01, 2020 16:29:53.150479 CET'`
`date_string_cest = 'Apr 01, 2020 16:29:53.150479 CEST'`

The previous command specified the format: 
`pd.to_datetime(date_string_cet, format='%b %d, %Y %H:%M:%S.%f %Z')`

Which gave an output of:
`Timestamp('2020-04-01 16:29:53.150479+0200', tz='CET')`

Now by not specifying the format, using `pd.to_datetime(date_string_cet)` outputs:
`Timestamp('2020-04-01 16:29:53.150479+0200', tz='pytz.FixedOffset(120)')`

And also works with  `pd.to_datetime(date_string_cest)`:
`Timestamp('2020-04-01 16:29:53.150479+0200', tz='pytz.FixedOffset(120)')`

Although the information of the timezone is lost, the offset from UTC is kept, which might be enough for not losing any functionality.