### PR TITLE
Added SND timing plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ Here is an example of the report generated at the receiver side:
 
 ![get_traffic_stats_report_rcv](img/get_traffic_stats_report_rcv.png)
 
+### `plot-snd-timing`
+
+This script plots the delta between packet capture time and SRT packet timestamp based on a network `.pcap(ng)` trace file. Intermediate data is stored in `.csv` format in the same directory as the original file. Both sender and receiver side dumps are supported.
+
+Usage:
+```
+venv/bin/plot-snd-timing [OPTIONS] PATH
+```
+where `PATH` refers to `.pcap(ng)` file.
+
+Options:
+```
+Options:
+  --overwrite / --no-overwrite  If exists, overwrite the .csv file produced
+                                out of the .pcap(ng) one at the previous
+                                iterations of running the script.  [default:
+                                no-overwrite]
+  --help                        Show this message and exit.
+```
+
 ## 3. Data Preparation
 
 A `.pcap(ng)` trace file with measurements from a specific network interface and port collected at the sender/receiver side is used as a proxy for packet data collected by SRT. This trace file is preprocessed in `.csv` format with timestamp, source IP address, destination IP address, protocol, and other columns and rows representing observations (sent/received packets).

--- a/scripts/get_traffic_stats.py
+++ b/scripts/get_traffic_stats.py
@@ -207,8 +207,8 @@ class TrafficStats:
 		data_pkts_org_lost_cnt = int((seqnos_org.diff().dropna() - 1).sum())
 
 		# The number of packets considered unrecovered at the receiver.
-		# It means nor original, neither retransmitted packet with
-		# a particular sequence number hasn't reached the destination.
+		# It means neither original, nor re-transmitted packet with
+		# a particular sequence number has reached the destination.
 		seqnos = self.data_pkts['srt.seqno'].astype('int32').copy()
 		seqnos = seqnos.drop_duplicates().sort_values()
 		data_pkts_unrecovered_cnt = int((seqnos.diff().dropna() - 1).sum())

--- a/scripts/plot_snd_timing.py
+++ b/scripts/plot_snd_timing.py
@@ -1,0 +1,68 @@
+"""
+Script designed to collect and output network traffic statistics.
+"""
+import pathlib
+
+import click
+import pandas as pd
+import matplotlib.pyplot as plt
+
+import tcpdump_processing.convert as convert
+import tcpdump_processing.extract_packets as extract_packets
+
+
+class SRTDataIndex:
+	def __init__(self, srt_packets):
+		self.ctrl_pkts        = (srt_packets['srt.iscontrol'] == 1)
+		self.data_pkts = (srt_packets['srt.iscontrol'] == 0)
+		self.data_pkts_org = self.data_pkts & (srt_packets['srt.msg.rexmit'] == 0)
+
+
+@click.command()
+@click.argument(
+	'path', 
+	type=click.Path(exists=True)
+)
+@click.option(
+	'--overwrite/--no-overwrite',
+	default=False,
+	help=	'If exists, overwrite the .csv file produced out of the .pcap (or .pcapng) '
+			'tcpdump trace one at the previous iterations of running the script.',
+	show_default=True
+)
+def main(path, overwrite):
+	"""
+	This script parses .pcap or .pcapng tcpdump trace file captured at the receiver side, 
+	collects and outputs network traffic statistics.
+	"""
+	# Process tcpdump trace file and get SRT data packets only
+	# (either all data packets or probing packets only)
+	pcapng_filepath   = pathlib.Path(path)
+	csv_filepath      = convert.convert_to_csv(pcapng_filepath, overwrite)
+	
+	try:
+		srt_packets = extract_packets.extract_srt_packets(csv_filepath)
+	except extract_packets.UnexpectedColumnsNumber as error:
+		print(
+			f'Exception captured: {error} '
+			'Please try running the script with --overwrite option.'
+		)
+		return
+
+	if srt_packets.empty:
+		print("No SRT packets found.")
+		return
+		
+	index = SRTDataIndex(srt_packets)
+	print(srt_packets[index.data_pkts_org])
+	
+	df = srt_packets[index.data_pkts_org]
+	df['Delta'] = df['ws.time'] * 1000000 - df['srt.timestamp']
+	print(df)
+	df.plot.scatter(x = 'ws.time', y = 'Delta')
+	plt.show()
+
+
+
+if __name__ == '__main__':
+	main()

--- a/scripts/plot_snd_timing.py
+++ b/scripts/plot_snd_timing.py
@@ -1,5 +1,6 @@
 """
-Script designed to collect and output network traffic statistics.
+Script designed to plot delta between packet capture time (Wireshark) and
+SRT packet timestamp.
 """
 import pathlib
 
@@ -32,8 +33,8 @@ class SRTDataIndex:
 )
 def main(path, overwrite):
 	"""
-	This script parses .pcap or .pcapng tcpdump trace file captured at the receiver side, 
-	collects and outputs network traffic statistics.
+	This script parses .pcap or .pcapng tcpdump trace file captured at the receiver side (preferably), 
+	and plots time delta between SRT packet timestamp and packet arrival time captured by Wireshark.
 	"""
 	# Process tcpdump trace file and get SRT data packets only
 	# (either all data packets or probing packets only)
@@ -59,9 +60,8 @@ def main(path, overwrite):
 	df = srt_packets[index.data_pkts_org]
 	df['Delta'] = df['ws.time'] * 1000000 - df['srt.timestamp']
 	print(df)
-	df.plot.scatter(x = 'ws.time', y = 'Delta')
+	df.plot.scatter(x = 'ws.time', xlabel = 'Time, s', y = 'Delta', ylabel = 'TS Delta, µs')
 	plt.show()
-
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     entry_points={
         'console_scripts': [
             'extract-packets = tcpdump_processing.extract_packets:main',
-            'get-traffic-stats = scripts.get_traffic_stats:main'
+            'get-traffic-stats = scripts.get_traffic_stats:main',
+            'plot-snd-timing = scripts.plot_snd_timing:main'
         ],
     },
 )


### PR DESCRIPTION
Plot the difference between a packet capturing timestamp and the SRT packet timestamp to estimate the delay dynamics.
Helps to investigate, e.g. if packets manage to arrive within the specified SRT latency.
Example output (maximum delay is up to 300 ms; ok-ish with SRT latency of 250 ms):

<img src="https://user-images.githubusercontent.com/12700120/187175258-133ae818-b2f8-4271-9e3f-809cc8e0a754.png" width="400" />

### TODO

- [x] Add description to the README