### PR TITLE
Apply datetime timezone mapping

### DIFF
--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -9,6 +9,7 @@ import pathlib
 
 import click
 import pandas as pd
+import dateutil
 
 import tcpdump_processing.convert as convert
 
@@ -139,10 +140,15 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'data.len'
 	]
 
+	tzmapping = {
+		'CET': dateutil.tz.gettz('Europe/Berlin'),
+		'CEST': dateutil.tz.gettz('Europe/Berlin')
+	}
+	
 	# It's either a dataframe with SRT only packets or an empty dataframe
 	# if there is no SRT packets in packets dataframe
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
-	srt_packets['frame.time'] = pd.to_datetime(srt_packets['frame.time'])
+	srt_packets['frame.time'].apply(dateutil.parser.parse, tzinfos=tzmapping)
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
 	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int16')

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -148,7 +148,8 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 	# It's either a dataframe with SRT only packets or an empty dataframe
 	# if there is no SRT packets in packets dataframe
 	srt_packets = packets[packets['ws.protocol'] == 'SRT'].copy()
-	srt_packets['frame.time'].apply(dateutil.parser.parse, tzinfos=tzmapping)
+	srt_packets['frame.time'].replace('W. Europe Daylight Time','CEST', inplace=True, regex=True)
+	srt_packets['frame.time'] = srt_packets['frame.time'].apply(dateutil.parser.parse, tzinfos=tzmapping)
 	srt_packets['srt.iscontrol'] = srt_packets['srt.iscontrol'].astype('int8')
 	srt_packets['srt.timestamp'] = srt_packets['srt.timestamp'].astype('int64')
 	srt_packets['udp.length'] = srt_packets['udp.length'].fillna(0).astype('int16')


### PR DESCRIPTION
Fixes the following warning:

```
dateutil\parser\_parser.py:1207: UnknownTimezoneWarning: tzname CET identified but not understood.
Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.
In a future version, this will raise an exception.
```
when the following time is parsed:
```
May  2, 2023 18:29:52.295798000 CET
```

Followed this suggestion: https://stackoverflow.com/questions/67061724/panda-to-datetime-raises-warning-tzname-cet-identified-but-not-understood


Also fixed 
```shell
  File "D:\Projects\srt\lib-tcpdump-processing\venv\lib\site-packages\dateutil\parser\_parser.py", line 643, in parse
    raise ParserError("Unknown string format: %s", timestr)
dateutil.parser._parser.ParserError: Unknown string format: Apr  1, 2020 16:29:53.150479000 W. Europe Daylight Time
```

with a workaround
```python
srt_packets['frame.time'].replace('W. Europe Daylight Time','CEST', inplace=True, regex=True)
```