### PR TITLE
Addressed FutureWarning with str.replace and regex=False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 # Dependencies for using the library
 install_requires = [
     'click >=7.0',
-    'pandas >=0.25.1',
+    'pandas >=2.0.1',
     'pathlib >=1.0.1',
 ]
 

--- a/tcpdump_processing/extract_packets.py
+++ b/tcpdump_processing/extract_packets.py
@@ -93,11 +93,11 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'category',		# _ws.col.Protocol (ws.protocol)
 		'int16',		# _ws.col.Length (ws.length)
 		'object',		# _ws.col.Info (ws.info)
-		'float16',		# udp.length
-		'float16',		# srt.iscontrol
+		'float32',		# udp.length
+		'float32',		# srt.iscontrol
 		'category',		# srt.type
 		'float64',		# srt.seqno
-		'float16',		# srt.msg.rexmit
+		'float32',		# srt.msg.rexmit
 		'float64',		# srt.timestamp
 		'category',		# srt.id
 		'float64',		# srt.ack_seqno
@@ -106,7 +106,7 @@ def extract_srt_packets(filepath: pathlib.Path) -> pd.DataFrame:
 		'float64',		# srt.rate
 		'float64',		# srt.bw
 		'float64',		# srt.rcvrate
-		'float16'		# data.len
+		'float32'		# data.len
 	]
 
 	columns_types = dict(zip(columns, types))


### PR DESCRIPTION
This PR is addressing the following future warnings
```
/Users/msharabayko/projects/srt/lib-tcpdump-processing/tcpdump_processing/extract_packets.py:158: FutureWarning: The default value of regex will change from True to False in a future version.
  srt_packets['frame.time'] = srt_packets['frame.time'].str.replace('W. Europe Standard Time', 'CET')
/Users/msharabayko/projects/srt/lib-tcpdump-processing/tcpdump_processing/extract_packets.py:159: FutureWarning: The default value of regex will change from True to False in a future version.
  srt_packets['frame.time'] = srt_packets['frame.time'].str.replace('W. Europe Daylight Time', 'CEST')
```
that appeared after merging PR #47. `regex` argument of `str.replace` is meant to be False there, however, this is only true since version 2.0 of `pandas`.

`float16` `dtype` is giving a KeyError when reading csv with `pandas`, that's why I changed it to `float32`.